### PR TITLE
fix ReadctorConfig not merging user config correctly

### DIFF
--- a/src/RedactorConfig.php
+++ b/src/RedactorConfig.php
@@ -81,7 +81,7 @@ class RedactorConfig
         $this->plugins = $this->getDefaultPlugins();
 
         if (is_array($extension->getConfig()['plugins'])) {
-            $this->plugins = array_replace_recursive($plugins, $extension->getConfig()['plugins']);
+            $this->plugins = array_replace_recursive($this->plugins, $extension->getConfig()['plugins']);
         }
 
         return $this->plugins;


### PR DESCRIPTION
As already discussed in Slack this PR fixes following error:

![image](https://user-images.githubusercontent.com/9105243/97989533-f678f700-1dde-11eb-9aad-6b0992d9d451.png)
