### PR TITLE
added the image key to the default config array

### DIFF
--- a/src/RedactorConfig.php
+++ b/src/RedactorConfig.php
@@ -90,6 +90,18 @@ class RedactorConfig
     public function getDefaults()
     {
         return [
+            'image' => [
+                'upload' => $this->urlGenerator->generate('bolt_article_upload', ['location' => 'files']),
+                'select' => $this->urlGenerator->generate('bolt_article_images', [
+                    '_csrf_token' => $this->csrfTokenManager->getToken('bolt_article')->getValue(),
+                    'foo' => '1', // To ensure token is cut off correctly
+                ]),
+                'data' => [
+                    '_csrf_token' => $this->csrfTokenManager->getToken('bolt_article')->getValue(),
+                ],
+                'multiple' => false,
+                'thumbnail' => '1000×1000×max',
+            ],
             'imageUpload' => $this->urlGenerator->generate('bolt_redactor_upload', ['location' => 'files']),
             'imageUploadParam' => 'file',
             'multipleUpload' => 'false',


### PR DESCRIPTION
Fixes to upload an image using WYSIWYG editor (see https://github.com/bolt/core/issues/2244).

Fixes #2244

Changelog
---------
* Fixed: Something that was broken (see #https://github.com/bolt/core/issues/2244)
