### PR TITLE
Replace deprecated DOMNodeInserted listener with MutationObserver

### DIFF
--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -19,7 +19,7 @@
         }
     };
 
-function initRedactors() {
+    function initRedactors() {
         $('.redactor-field').removeClass('d-none');
         $R('.redactor-field', {{ redactor_settings() }});
     }

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -19,11 +19,6 @@
         }
     };
 
-    function initRedactors() {
-        $('.redactor-field').removeClass('d-none');
-        $R('.redactor-field', {{ redactor_settings() }});
-    }
-
     $(document).on('DOMNodeInserted', function(e) {
         if ( $(e.target).hasClass('collection-item') ) {
             initRedactors();

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -5,14 +5,12 @@
     $R.options = {
         callbacks: {
             image: {
-                uploadError: function(response)
-                {
+                uploadError: function(response) {
                     alert(response.message);
                 }
             },
             file: {
-                uploadError: function(response)
-                {
+                uploadError: function(response) {
                     alert(response.message);
                 }
             }
@@ -24,12 +22,24 @@
         $R('.redactor-field', {{ redactor_settings() }});
     }
 
-    $(document).on('DOMNodeInserted', function(e) {
-        if ( $(e.target).hasClass('collection-item') ) {
-            initRedactors();
+    const observerRedactor = new MutationObserver((mutations) => {
+        for (let mutation of mutations) {
+            if (mutation.type === 'childList' && mutation.addedNodes.length) {
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE
+                        && node.classList.contains('collection-item')) {
+                        initRedactors();
+                    }
+                });
+            }
         }
     });
 
-    initRedactors();
-</script>
+    observerRedactor.observe(document.body, {
+        childList: true,
+        subtree:   true
+    });
 
+    initRedactors();
+
+</script>

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -5,12 +5,14 @@
     $R.options = {
         callbacks: {
             image: {
-                uploadError: function(response) {
+                uploadError: function(response)
+                {
                     alert(response.message);
                 }
             },
             file: {
-                uploadError: function(response) {
+                uploadError: function(response)
+                {
                     alert(response.message);
                 }
             }
@@ -21,6 +23,12 @@
         $('.redactor-field').removeClass('d-none');
         $R('.redactor-field', {{ redactor_settings() }});
     }
+
+    $(document).on('DOMNodeInserted', function(e) {
+        if ( $(e.target).hasClass('collection-item') ) {
+            initRedactors();
+        }
+    });
 
     const observerRedactor = new MutationObserver((mutations) => {
         for (let mutation of mutations) {
@@ -41,5 +49,4 @@
     });
 
     initRedactors();
-
 </script>

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -29,8 +29,7 @@
         for (let mutation of mutations) {
             if (mutation.type === 'childList' && mutation.addedNodes.length) {
                 mutation.addedNodes.forEach(node => {
-                    if (node.nodeType === Node.ELEMENT_NODE
-                        && node.classList.contains('collection-item')) {
+                    if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('collection-item')) {
                         initRedactors();
                     }
                 });

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -19,11 +19,11 @@
         }
     };
 
-    $(document).on('DOMNodeInserted', function(e) {
-        if ( $(e.target).hasClass('collection-item') ) {
-            initRedactors();
-        }
-    });
+function initRedactors() {
+        $('.redactor-field').removeClass('d-none');
+        $R('.redactor-field', {{ redactor_settings() }});
+    }
+
 
     const observerRedactor = new MutationObserver((mutations) => {
         for (let mutation of mutations) {


### PR DESCRIPTION
Replace deprecated DOMNodeInserted listener with MutationObserver 
- Resolve Chrome incompatibility when adding collection items or other dynamic nodes  
- Restore cross-browser support (Chrome, Mozilla, etc.)  
- Future-proof DOM mutation handling