### PR TITLE
Replace deprecated DOMNodeInserted listener with MutationObserver

### DIFF
--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -24,10 +24,22 @@
         $R('.redactor-field', {{ redactor_settings() }});
     }
 
-    $(document).on('DOMNodeInserted', function(e) {
-        if ( $(e.target).hasClass('collection-item') ) {
-            initRedactors();
+const observerRedactor = new MutationObserver((mutations) => {
+        for (let mutation of mutations) {
+            if (mutation.type === 'childList' && mutation.addedNodes.length) {
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE
+                        && node.classList.contains('collection-item')) {
+                        initRedactors();
+                    }
+                });
+            }
         }
+    });
+
+    observerRedactor.observe(document.body, {
+        childList: true,
+        subtree:   true
     });
 
     initRedactors();


### PR DESCRIPTION
Replace deprecated DOMNodeInserted listener with MutationObserver
- Resolve Chrome incompatibility when adding collection items or other dynamic nodes  
- Restore cross-browser support (Chrome, Mozilla, etc.)  
- Future-proof DOM mutation handling